### PR TITLE
Observability Day – Session 1

### DIFF
--- a/services/backend-for-frontend-nodejs/src/tracing.ts
+++ b/services/backend-for-frontend-nodejs/src/tracing.ts
@@ -17,7 +17,7 @@ const sdk = new NodeSDK({
     traceExporter,
     instrumentations: [getNodeAutoInstrumentations(
         //  { '@opentelemetry/instrumentation-fs': { enabled: false } } // INSTRUMENTATION: remove the noisy spans that we don't use
-    ), // new UndiciInstrumentation() // INSTRUMENTATION: 'fetch' needs this, and it isn't in getNodeAutoInstrumentations yet.
+    ), new UndiciInstrumentation() // INSTRUMENTATION: 'fetch' needs this, and it isn't in getNodeAutoInstrumentations yet.
     ]
 });
 

--- a/services/backend-for-frontend-nodejs/src/tracing.ts
+++ b/services/backend-for-frontend-nodejs/src/tracing.ts
@@ -16,7 +16,7 @@ const traceExporter = new OTLPTraceExporter();
 const sdk = new NodeSDK({
     traceExporter,
     instrumentations: [getNodeAutoInstrumentations(
-        //  { '@opentelemetry/instrumentation-fs': { enabled: false } } // INSTRUMENTATION: remove the noisy spans that we don't use
+         { '@opentelemetry/instrumentation-fs': { enabled: false } } // INSTRUMENTATION: remove the noisy spans that we don't use
     ), new UndiciInstrumentation() // INSTRUMENTATION: 'fetch' needs this, and it isn't in getNodeAutoInstrumentations yet.
     ]
 });

--- a/services/meminator-nodejs/src/shellOut.ts
+++ b/services/meminator-nodejs/src/shellOut.ts
@@ -16,46 +16,46 @@ type ProcessOutput = {
  * @returns a promise that resolves when the process exits with code 0
  */
 export function spawnProcess(commandName: string, args: string[]): Promise<ProcessOutput> {
-    // return trace.getTracer('meminator').startActiveSpan(commandName, {
-    //     attributes: {
-    //         "app.command.name": commandName,
-    //         "app.command.args": args.join(' ')
-    //     }
-    // }, (span) => { #INSTRUMENTATION: wrap important unit of work in a span
-    return new Promise<ProcessOutput>((resolve, reject) => {
-        const process = spawn(commandName, args);
-        let stderrOutput = '';
-        process.stderr.on('data', (data) => {
-            stderrOutput += data;
-        });
+    return trace.getTracer('meminator').startActiveSpan(commandName, {
+        attributes: {
+            "app.command.name": commandName,
+            "app.command.args": args.join(' ')
+        }
+    }, (span) => { // INSTRUMENTATION: wrap important unit of work in a span
+        return new Promise<ProcessOutput>((resolve, reject) => {
+            const process = spawn(commandName, args);
+            let stderrOutput = '';
+            process.stderr.on('data', (data) => {
+                stderrOutput += data;
+            });
 
-        let stdout = '';
-        process.stdout.on('data', (data) => {
-            stdout += data;
-        });
+            let stdout = '';
+            process.stdout.on('data', (data) => {
+                stdout += data;
+            });
 
-        process.on('error', (error) => {
-            // span.recordException(error);
-            // span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-            // span.end();
-            reject(error);
-        });
+            process.on('error', (error) => {
+                span.recordException(error);
+                span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+                span.end();
+                reject(error);
+            });
 
-        process.on('close', (code) => {
-            // span.setAttributes({
-            //     'app.command.exitCode': code || 0,
-            //     'app.command.stderr': stderrOutput,
-            //     'app.command.stdout': stdout
-            // });
-            if (code !== 0) {
-                // span.setStatus({ code: SpanStatusCode.ERROR, message: "Process exited with " + code });
-                // span.end();
-                reject(new Error(`Process exited with non-zero code: ${code}`));
-            } else {
-                // span.end();
-                resolve({ stdout, stderr: stderrOutput });
-            }
+            process.on('close', (code) => {
+                span.setAttributes({
+                    'app.command.exitCode': code || 0,
+                    'app.command.stderr': stderrOutput,
+                    'app.command.stdout': stdout
+                });
+                if (code !== 0) {
+                    span.setStatus({ code: SpanStatusCode.ERROR, message: "Process exited with " + code });
+                    span.end();
+                    reject(new Error(`Process exited with non-zero code: ${code}`));
+                } else {
+                    span.end();
+                    resolve({ stdout, stderr: stderrOutput });
+                }
+            });
         });
     });
-    // });
 }


### PR DESCRIPTION
# Session 1 Takeaways

- Attributes are unlimited; use them!
- You don’t get telemetry from a span unless you end the span using `span.end()`
- You can disable noisy fs instrumentation
- You can use `stderrOutput` and `stdout` as attributes on a span to help debug issues
- Data should show up in honeycomb within 5 seconds (SLA) once they receive the data
- Recommended to put relevant metrics on traces rather than separate metrics collection so that you can see “during this span”, what was this metric?
- Can add a custom span processor to auto-apply common metrics to every span, such as memory, cpu, free space, etc – or use npm package MetricsAsAttributesProcessor
- Spans cost money, but attributes don’t
